### PR TITLE
Refactor options flow to remove config_entry

### DIFF
--- a/custom_components/device_tools/config_flow.py
+++ b/custom_components/device_tools/config_flow.py
@@ -370,16 +370,15 @@ class DeviceToolsConfigFlow(ConfigFlow, domain=DOMAIN):
     @callback
     def async_get_options_flow(
         config_entry: ConfigEntry,
-    ) -> OptionsFlow:
+    ) -> OptionsFlowHandler:
         """Create the options flow."""
-        return OptionsFlowHandler(config_entry)
+        return OptionsFlowHandler()
 
 
 class OptionsFlowHandler(OptionsFlow):
-    def __init__(self, config_entry: ConfigEntry) -> None:
+    def __init__(self) -> None:
         """Initialize options flow."""
 
-        self.config_entry = config_entry
         self.device_modification: DeviceModification = config_entry.data[
             "device_modification"
         ]


### PR DESCRIPTION
Follows the guidance in the Home Assistant blog: https://developers.home-assistant.io/blog/2024/11/12/options-flow/#backwards-compatibility

Fixes #41

Note: I haven’t set up local development for custom components yet, so I’ve not tested this locally. @EuleMitKeule if you don’t have time to validate it, I’ll test in a few days by temporarily using my fork and loading it in HACS. This is not the ideal testing workflow and I plan to learn the proper flow in the future.