### PR TITLE
docs: Auto-translate README and Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
+
+<div align="right">
+  <details>
+    <summary >🌐 Language</summary>
+    <div>
+      <div align="center">
+        <a href="https://openaitx.github.io/view.html?user=EuleMitKeule&project=device-tools&lang=en">English</a>
+        | <a href="https://openaitx.github.io/view.html?user=EuleMitKeule&project=device-tools&lang=zh-CN">简体中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=EuleMitKeule&project=device-tools&lang=zh-TW">繁體中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=EuleMitKeule&project=device-tools&lang=ja">日本語</a>
+        | <a href="https://openaitx.github.io/view.html?user=EuleMitKeule&project=device-tools&lang=ko">한국어</a>
+        | <a href="https://openaitx.github.io/view.html?user=EuleMitKeule&project=device-tools&lang=hi">हिन्दी</a>
+        | <a href="https://openaitx.github.io/view.html?user=EuleMitKeule&project=device-tools&lang=th">ไทย</a>
+        | <a href="https://openaitx.github.io/view.html?user=EuleMitKeule&project=device-tools&lang=fr">Français</a>
+        | <a href="https://openaitx.github.io/view.html?user=EuleMitKeule&project=device-tools&lang=de">Deutsch</a>
+        | <a href="https://openaitx.github.io/view.html?user=EuleMitKeule&project=device-tools&lang=es">Español</a>
+        | <a href="https://openaitx.github.io/view.html?user=EuleMitKeule&project=device-tools&lang=it">Italiano</a>
+        | <a href="https://openaitx.github.io/view.html?user=EuleMitKeule&project=device-tools&lang=ru">Русский</a>
+        | <a href="https://openaitx.github.io/view.html?user=EuleMitKeule&project=device-tools&lang=pt">Português</a>
+        | <a href="https://openaitx.github.io/view.html?user=EuleMitKeule&project=device-tools&lang=nl">Nederlands</a>
+        | <a href="https://openaitx.github.io/view.html?user=EuleMitKeule&project=device-tools&lang=pl">Polski</a>
+        | <a href="https://openaitx.github.io/view.html?user=EuleMitKeule&project=device-tools&lang=ar">العربية</a>
+        | <a href="https://openaitx.github.io/view.html?user=EuleMitKeule&project=device-tools&lang=fa">فارسی</a>
+        | <a href="https://openaitx.github.io/view.html?user=EuleMitKeule&project=device-tools&lang=tr">Türkçe</a>
+        | <a href="https://openaitx.github.io/view.html?user=EuleMitKeule&project=device-tools&lang=vi">Tiếng Việt</a>
+        | <a href="https://openaitx.github.io/view.html?user=EuleMitKeule&project=device-tools&lang=id">Bahasa Indonesia</a>
+        | <a href="https://openaitx.github.io/view.html?user=EuleMitKeule&project=device-tools&lang=as">অসমীয়া</
+      </div>
+    </div>
+  </details>
+</div>
+
 [![My Home Assistant](https://img.shields.io/badge/Home%20Assistant-%2341BDF5.svg?style=flat&logo=home-assistant&label=My)](https://my.home-assistant.io/redirect/hacs_repository/?owner=EuleMitKeule&repository=device-tools&category=integration)
 
 ![GitHub License](https://img.shields.io/github/license/eulemitkeule/device-tools)


### PR DESCRIPTION
Added language badges to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, and Russian 20 languages.
System will auto-update translation for README and Wiki when this repository updated, and support multiple languages google/bing SEO search, and it's open source project, we can change web or local file mode.

The updated links can be previewed in my forked repository: https://github.com/openaitx-system/device-tools/tree/Auto_translate_README_and_Wiki

Demo links : 
- [Español](https://openaitx.github.io/view.html?user=EuleMitKeule&project=device-tools&lang=es)
- [简体中文](https://openaitx.github.io/view.html?user=EuleMitKeule&project=device-tools&lang=zh-CN)
- [日本語](https://openaitx.github.io/view.html?user=EuleMitKeule&project=device-tools&lang=ja)
- [한국어](https://openaitx.github.io/view.html?user=EuleMitKeule&project=device-tools&lang=ko)
- [Français](https://openaitx.github.io/view.html?user=EuleMitKeule&project=device-tools&lang=fr)
..


<img width="1178" height="537" alt="Image" src="https://github.com/user-attachments/assets/7cd54a88-59c1-455f-9c7d-2db7f05b2962  " />

If this doesn't align with your expectations, feel free to close this PR. Thanks for your time! 🙌
